### PR TITLE
Domain migration, hub OAuth fix, address autocomplete

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-goto.kenefeck.com
+gototoastmasters.com.au

--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -454,7 +454,7 @@
 <script>
   // ── CONFIG ─────────────────────────────────────────────────────────────
   const WEBAPP_URL   = 'https://script.google.com/macros/s/AKfycbwJDm5DcJ3Emm5Q1Gf5mKEzLwZBHcXEetxb1XEGc1Z1q-8hJOdC9mox2LeIG07lP1AnxQ/exec';
-  const MAPS_API_KEY = 'PASTE_YOUR_MAPS_API_KEY_HERE'; // Google Maps Platform → Maps JavaScript API + Places API
+  const MAPS_API_KEY = 'AIzaSyCAdLRQ-BSBlZFFas_kMCbqYTXh1irMTMc'; // Google Maps Platform → Maps JavaScript API + Places API
 
   // ── POPULATE JOIN MONTH SELECT ─────────────────────────────────────────
   (function populateJoinMonths() {

--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -448,12 +448,13 @@
 </main>
 
 <footer>
-  &copy; GOTO Toastmasters · Melbourne CBD · <a href="https://goto.kenefeck.com">goto.kenefeck.com</a>
+  &copy; GOTO Toastmasters · Melbourne CBD · <a href="https://gototoastmasters.com.au">gototoastmasters.com.au</a>
 </footer>
 
 <script>
   // ── CONFIG ─────────────────────────────────────────────────────────────
-  const WEBAPP_URL = 'https://script.google.com/macros/s/AKfycbwJDm5DcJ3Emm5Q1Gf5mKEzLwZBHcXEetxb1XEGc1Z1q-8hJOdC9mox2LeIG07lP1AnxQ/exec';
+  const WEBAPP_URL   = 'https://script.google.com/macros/s/AKfycbwJDm5DcJ3Emm5Q1Gf5mKEzLwZBHcXEetxb1XEGc1Z1q-8hJOdC9mox2LeIG07lP1AnxQ/exec';
+  const MAPS_API_KEY = 'PASTE_YOUR_MAPS_API_KEY_HERE'; // Google Maps Platform → Maps JavaScript API + Places API
 
   // ── POPULATE JOIN MONTH SELECT ─────────────────────────────────────────
   (function populateJoinMonths() {
@@ -592,6 +593,67 @@
       btn.textContent = 'Submit membership application';
     }
   });
+
+  // ── PLACES AUTOCOMPLETE ────────────────────────────────────────────────
+  // Fills structured address fields when the user selects a suggestion.
+  // Degrades gracefully — form works normally if the API key is not configured.
+  function initPlacesAutocomplete() {
+    const input = document.getElementById('addressLine1');
+    if (!input || !window.google?.maps?.places) return;
+
+    const ac = new google.maps.places.Autocomplete(input, {
+      componentRestrictions: { country: 'au' },
+      types:  ['address'],
+      fields: ['address_components'],
+    });
+
+    // Prevent Enter key from submitting the form while the suggestion
+    // dropdown is open.
+    google.maps.event.addDomListener(input, 'keydown', e => {
+      if (e.keyCode === 13) e.preventDefault();
+    });
+
+    ac.addListener('place_changed', () => {
+      const place = ac.getPlace();
+      if (!place.address_components) return;
+
+      const get = (type, useLong = true) => {
+        const c = place.address_components.find(c => c.types.includes(type));
+        return c ? (useLong ? c.long_name : c.short_name) : '';
+      };
+
+      const streetNum  = get('street_number');
+      const route      = get('route');
+      const subpremise = get('subpremise');         // unit / level
+      const locality   = get('locality')
+                      || get('sublocality_level_1')
+                      || get('colloquial_area');
+      const state      = get('administrative_area_level_1', false); // VIC, NSW…
+      const postcode   = get('postal_code');
+      const country    = get('country');             // Australia
+
+      document.getElementById('addressLine1').value   = [streetNum, route].filter(Boolean).join(' ');
+      document.getElementById('addressLine2').value   = subpremise || '';
+      document.getElementById('addressCity').value    = locality;
+      document.getElementById('addressState').value   = state;
+      document.getElementById('addressCountry').value = country || 'Australia';
+      document.getElementById('addressPostcode').value = postcode;
+
+      // Move focus to unit field if one was found, otherwise postcode
+      document.getElementById(subpremise ? 'addressLine2' : 'addressPostcode').focus();
+    });
+  }
+
+  // Load Maps JS API only when key is configured — form works without it
+  (function loadMapsApi() {
+    if (!MAPS_API_KEY || MAPS_API_KEY.startsWith('PASTE_')) return;
+    const s   = document.createElement('script');
+    s.src     = `https://maps.googleapis.com/maps/api/js?key=${MAPS_API_KEY}&libraries=places&callback=initPlacesAutocomplete`;
+    s.async   = true;
+    s.defer   = true;
+    s.onerror = () => console.warn('Google Maps failed to load — address autocomplete unavailable.');
+    document.head.appendChild(s);
+  })();
 </script>
 
 </body>

--- a/docs/onboarding/index.html
+++ b/docs/onboarding/index.html
@@ -409,7 +409,7 @@
 // TODO: Replace with your Google Cloud OAuth 2.0 Client ID.
 // Create at https://console.cloud.google.com → APIs & Services → Credentials
 // → Create Credentials → OAuth client ID → Web application
-// Add https://goto.kenefeck.com as an Authorised JavaScript origin.
+// Add https://gototoastmasters.com.au as an Authorised JavaScript origin.
 const GOOGLE_CLIENT_ID = '303221448159-6i35t5bc5k5ukncm1lj36u3qb2731j2d.apps.googleusercontent.com';
 
 const SHEET_ID  = '1PSH2PuwmqhXxDKnlCw2XrV3aHjZpVgqXdYk16gveRho';
@@ -456,13 +456,24 @@ function gisLoaded() {
     client_id: GOOGLE_CLIENT_ID,
     scope: SCOPES,
     callback: async (resp) => {
+      // 'interaction_required' / 'access_denied' means no prior grant exists.
+      // Retry with explicit prompt so the user can approve the Sheets scope.
+      if (resp.error === 'interaction_required' || resp.error === 'access_denied') {
+        tokenClient.requestAccessToken({ prompt: 'consent' });
+        return;
+      }
       if (resp.error) { showDenied(); return; }
+
       accessToken = resp.access_token;
       gapi.client.setToken({ access_token: accessToken });
       await loadAllData();
-      document.getElementById('login-view').style.display = 'none';
-      document.getElementById('app-view').style.display   = 'block';
-      showView('dashboard');
+
+      // loadAllData sets currentUser on success; stays null on error / non-committee.
+      if (currentUser) {
+        document.getElementById('login-view').style.display = 'none';
+        document.getElementById('app-view').style.display   = 'block';
+        showView('dashboard');
+      }
     },
   });
 
@@ -488,9 +499,11 @@ function maybeRender() {
 
 // Called when user clicks Google Sign In button
 function handleCredentialResponse(response) {
-  // We have an ID token — now request an access token for Sheets API
+  // ID token received — now request an OAuth access token for the Sheets API.
+  // prompt: '' (default) lets GIS show the consent screen if not yet granted.
+  // prompt: 'none' silently fails on first use and never calls the callback.
   showLoading('Signing in…');
-  tokenClient.requestAccessToken({ prompt: 'none' });
+  tokenClient.requestAccessToken({ prompt: '' });
 }
 
 function signOut() {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: GOTO Toastmasters 
 site_description: 'A website for the Melbourne, AU based Toastmasters group'
 site_author: 'Rob Kenefeck'
-site_url: 'https://goto.kenefeck.com'
+site_url: 'https://gototoastmasters.com.au'
 
 copyright: |
   &copy; The information on this website is for the sole use of Toastmasters' members, for Toastmasters business only. It is not to be used for solicitation and distribution of non-Toastmasters material or information. All rights reserved. Toastmasters International, the Toastmasters International logo and all other Toastmasters International trademarks and copyrights are the sole property of Toastmasters International and may be used only by permission.


### PR DESCRIPTION
## Summary

- **Domain**: CNAME + `mkdocs.yml` `site_url` + footer link migrated from `goto.kenefeck.com` → `gototoastmasters.com.au`
- **Onboarding hub — OAuth signin fix**: `prompt: 'none'` was silently dropping the callback on first use (no prior grant), leaving the spinner stuck on "Signing in…". Changed to `prompt: ''`, added `interaction_required` fallback to retry with `prompt: 'consent'`, and gated `app-view` reveal on `currentUser` being set
- **Join form — Places Autocomplete**: Google Maps Places API wired to `addressLine1`; on selection fills all structured address fields (line1, unit, suburb, state, postcode, country); degrades gracefully if key not configured; Maps API key configured
- **Onboarding hub comment**: authorised JavaScript origin comment updated to new domain

## Test plan

- [ ] `gototoastmasters.com.au` serves the site
- [ ] Join form address field shows Google suggestions when typing a street address
- [ ] Onboarding hub sign-in completes without spinning
- [ ] Hub shows "Access denied" for non-committee Google accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)