### PR TITLE
Fix Google Places Autocomplete conflict on address field

### DIFF
--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -148,12 +148,33 @@
       font-weight: 500;
       cursor: pointer;
     }
+
+    /* Custom radio button */
     .radio-group input[type="radio"] {
-      width: 16px; height: 16px;
-      accent-color: var(--primary);
+      appearance: none;
+      -webkit-appearance: none;
+      width: 18px; height: 18px;
+      border: 2px solid var(--border);
+      border-radius: 50%;
       cursor: pointer;
+      flex-shrink: 0;
+      transition: border-color .15s, background .15s;
+      position: relative;
+    }
+    .radio-group input[type="radio"]:hover {
+      border-color: var(--primary-light);
+    }
+    .radio-group input[type="radio"]:checked {
+      border-color: var(--primary);
+      background: var(--primary);
+      box-shadow: inset 0 0 0 3px #fff;
+    }
+    .radio-group input[type="radio"]:focus-visible {
+      outline: 3px solid var(--accent);
+      outline-offset: 2px;
     }
 
+    /* Custom checkbox */
     .checkbox-row {
       display: flex;
       align-items: flex-start;
@@ -161,10 +182,37 @@
       margin-bottom: 24px;
     }
     .checkbox-row input[type="checkbox"] {
-      width: 16px; height: 16px;
-      margin-top: 2px;
-      accent-color: var(--primary);
+      appearance: none;
+      -webkit-appearance: none;
+      width: 18px; height: 18px;
+      min-width: 18px;
+      margin-top: 1px;
+      border: 2px solid var(--border);
+      border-radius: 4px;
+      cursor: pointer;
       flex-shrink: 0;
+      transition: border-color .15s, background .15s;
+      position: relative;
+      display: grid;
+      place-content: center;
+    }
+    .checkbox-row input[type="checkbox"]:hover {
+      border-color: var(--primary-light);
+    }
+    .checkbox-row input[type="checkbox"]:checked {
+      background: var(--primary);
+      border-color: var(--primary);
+    }
+    .checkbox-row input[type="checkbox"]:checked::after {
+      content: '';
+      width: 10px; height: 6px;
+      border-left: 2px solid #fff;
+      border-bottom: 2px solid #fff;
+      transform: rotate(-45deg) translateY(-1px);
+    }
+    .checkbox-row input[type="checkbox"]:focus-visible {
+      outline: 3px solid var(--accent);
+      outline-offset: 2px;
     }
     .checkbox-row label {
       font-size: .8rem;

--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -347,7 +347,7 @@
 
       <div class="field">
         <label for="addressLine1">Address line 1 <span class="req">*</span></label>
-        <input type="text" id="addressLine1" name="addressLine1" autocomplete="address-line1" required placeholder="Street address">
+        <input type="text" id="addressLine1" name="addressLine1" autocomplete="address-line1" placeholder="Street address">
       </div>
 
       <div class="field">
@@ -601,19 +601,23 @@
     const input = document.getElementById('addressLine1');
     if (!input || !window.google?.maps?.places) return;
 
-    const ac = new google.maps.places.Autocomplete(input, {
-      componentRestrictions: { country: 'au' },
-      types:  ['address'],
-      fields: ['address_components'],
-    });
+    let ac = null;
 
-    // Prevent Enter key from submitting the form while the suggestion
-    // dropdown is open.
-    google.maps.event.addDomListener(input, 'keydown', e => {
-      if (e.keyCode === 13) e.preventDefault();
-    });
+    function attachAutocomplete() {
+      if (ac) return; // already attached — don't double-init
+      ac = new google.maps.places.Autocomplete(input, {
+        componentRestrictions: { country: 'au' },
+        types:  ['address'],
+        fields: ['address_components'],
+      });
 
-    ac.addListener('place_changed', () => {
+      // Prevent Enter key from submitting the form while the suggestion
+      // dropdown is open.
+      google.maps.event.addDomListener(input, 'keydown', e => {
+        if (e.keyCode === 13) e.preventDefault();
+      });
+
+      ac.addListener('place_changed', () => {
       const place = ac.getPlace();
       if (!place.address_components) return;
 
@@ -641,6 +645,18 @@
 
       // Move focus to unit field if one was found, otherwise postcode
       document.getElementById(subpremise ? 'addressLine2' : 'addressPostcode').focus();
+      });
+    } // end attachAutocomplete
+
+    // Attach Places only on first keystroke — this lets Chrome's native
+    // saved-address autofill work normally when the user clicks the field.
+    // Places activates only if the user actually starts typing.
+    input.addEventListener('keydown', function onFirstKey(e) {
+      // Ignore modifier-only keys (Tab, Shift, Ctrl, Alt, Meta)
+      if (e.key.length === 1 || e.key === 'Backspace' || e.key === 'Delete') {
+        attachAutocomplete();
+        input.removeEventListener('keydown', onFirstKey);
+      }
     });
   }
 


### PR DESCRIPTION
Lazy-init Places Autocomplete — attaches only on first keystroke rather than on page load. This lets Chrome's native saved-address autofill work without interference (no more ! icons appearing inside the field). Also removes `required` from addressLine1 since join.js already validates that at least one address line is present.