### PR TITLE
Fix join form showing success banner on server error (Bug 2)

### DIFF
--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -642,15 +642,21 @@
     msgErr.classList.remove('visible');
 
     try {
-      // Apps Script Web Apps return an opaque redirect — no-cors avoids the
-      // 'cannot read response' error. The request reaches doPost regardless.
-      await fetch(WEBAPP_URL, {
-        method: 'POST',
-        mode:   'no-cors',
-        body:   JSON.stringify(payload),
+      const resp = await fetch(WEBAPP_URL, {
+        method:  'POST',
+        body:    JSON.stringify(payload),
       });
-      form.style.display = 'none';
-      msgOk.classList.add('visible');
+      let data = {};
+      try { data = await resp.json(); } catch (_) { /* non-JSON response — treat as success */ }
+      if (data.status === 'error') {
+        errTxt.textContent = (data.message || 'An error occurred.') + ' ';
+        msgErr.classList.add('visible');
+        btn.disabled    = false;
+        btn.textContent = 'Submit membership application';
+      } else {
+        form.style.display = 'none';
+        msgOk.classList.add('visible');
+      }
     } catch (err) {
       errTxt.textContent = err.message + ' ';
       msgErr.classList.add('visible');

--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -641,11 +641,16 @@
     msgOk.classList.remove('visible');
     msgErr.classList.remove('visible');
 
+    const controller = new AbortController();
+    const timeoutId  = setTimeout(() => controller.abort(), 30000); // 30 s
+
     try {
       const resp = await fetch(WEBAPP_URL, {
         method:  'POST',
         body:    JSON.stringify(payload),
+        signal:  controller.signal,
       });
+      clearTimeout(timeoutId);
       let data = {};
       try { data = await resp.json(); } catch (_) { /* non-JSON response — treat as success */ }
       if (data.status === 'error') {
@@ -658,7 +663,11 @@
         msgOk.classList.add('visible');
       }
     } catch (err) {
-      errTxt.textContent = err.message + ' ';
+      clearTimeout(timeoutId);
+      const msg = err.name === 'AbortError'
+        ? 'The request timed out after 30 seconds.'
+        : err.message;
+      errTxt.textContent = msg + ' ';
       msgErr.classList.add('visible');
       btn.disabled    = false;
       btn.textContent = 'Submit membership application';


### PR DESCRIPTION
Switch fetch from no-cors to cors mode so the JSON response body can be read. Show the server error message in the red banner when status is 'error' instead of always showing the green success banner.