### PR TITLE
feat: add CSP and referrer-policy meta tags (Finding #2)

### DIFF
--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://ccdn.toastmasters.org; connect-src 'self' https://script.google.com;">
   <title>Join GOTO Toastmasters</title>
   <link rel="icon" href="https://ccdn.toastmasters.org/medias/files/brand-materials/loyal-blue-masthead-logo.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Adds partial security header mitigations via HTML meta tags (Option A — no Cloudflare dependency):
- referrer: strict-origin-when-cross-origin
- CSP: locks scripts/styles/fonts/images/connect to known origins; unsafe-inline required for existing inline script/style blocks

Residual gap: frame-ancestors and X-Content-Type-Options cannot be set via meta tags — accepted trade-off per decision to avoid Cloudflare.