### PR TITLE
fix: add script.googleusercontent.com to CSP connect-src

### DIFF
--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://ccdn.toastmasters.org; connect-src 'self' https://script.google.com;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://ccdn.toastmasters.org; connect-src 'self' https://script.google.com https://script.googleusercontent.com;">
   <title>Join GOTO Toastmasters</title>
   <link rel="icon" href="https://ccdn.toastmasters.org/medias/files/brand-materials/loyal-blue-masthead-logo.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary

- Fixes a critical regression introduced by PR #44: the CSP `connect-src` only listed `https://script.google.com`, but Apps Script responses redirect through `https://script.googleusercontent.com/macros/echo`. The browser blocked the redirect, causing the form to hang for 30 s with no user feedback while the submission had already executed server-side.
- Fix: add `https://script.googleusercontent.com` to `connect-src`.

## Test plan

- [ ] Submit the join form end-to-end — response returns without hanging
- [ ] CSP violation for `script.googleusercontent.com` no longer appears in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)