### PR TITLE
feat: hub UI for invoice PDF queue status (Retry PDF button)

### DIFF
--- a/docs/onboarding/index.html
+++ b/docs/onboarding/index.html
@@ -841,10 +841,14 @@ function renderApplicationReview(m, invoice, onboarding, googleSearch, name) {
     </div>` : ''}
     ${invoice
       ? `<p style="font-size:.8rem;color:var(--muted);margin-bottom:8px">
-           Invoice #${esc(invoice.invoice_number || invoice.invoice_number_ || invoice.invoice_no_ || '')} generated.
-           ${invoice.invoice_link
-             ? `<a href="${esc(invoice.invoice_link)}" target="_blank" rel="noopener" style="margin-left:8px">View PDF →</a>`
-             : ''}
+           Invoice #${esc(invoice.invoice_number || invoice.invoice_number_ || invoice.invoice_no_ || '')}.
+           ${invoice.pdf_status === 'Failed'
+             ? `<span style="color:var(--error);font-weight:600;margin-left:8px">⚠ PDF generation failed</span>`
+             : invoice.pdf_status === 'Queued' || invoice.pdf_status === 'Generating'
+               ? `<span style="color:var(--muted);margin-left:8px">⏳ PDF generating…</span>`
+               : invoice.invoice_link
+                 ? `<a href="${esc(invoice.invoice_link)}" target="_blank" rel="noopener" style="margin-left:8px">View PDF →</a>`
+                 : ''}
          </p>
          <table class="invoice-lines">
            <thead><tr><th>SKU</th><th style="text-align:right">Qty</th></tr></thead>
@@ -863,10 +867,14 @@ function renderApplicationReview(m, invoice, onboarding, googleSearch, name) {
     <div class="action-bar">
       <button class="btn btn-danger btn-sm" onclick="rejectMember('${esc(m.email)}')">Reject</button>
       <div class="spacer"></div>
+      ${invoice && invoice.pdf_status === 'Failed'
+        ? `<button class="btn btn-ghost btn-sm" onclick="retryInvoicePdf('${esc(m.email)}')">Retry PDF</button>`
+        : ''}
       <button class="btn btn-ghost btn-sm" onclick="generateInvoiceFlow('${esc(m.email)}')">Amend Invoice</button>
       <button class="btn btn-success"
         onclick="approveAndSend('${esc(m.email)}')"
-        ${isPendingReview ? 'disabled title="Resolve membership category first"' : ''}>
+        ${isPendingReview ? 'disabled title="Resolve membership category first"' : ''}
+        ${invoice && (invoice.pdf_status === 'Queued' || invoice.pdf_status === 'Generating') ? 'title="PDF still generating — click to generate now and send"' : ''}>
         Approve &amp; Send Invoice
       </button>
     </div>`;
@@ -1126,6 +1134,19 @@ function renderResources() {
 // ══════════════════════════════════════════════════════════════════════════════
 // ACTIONS
 // ══════════════════════════════════════════════════════════════════════════════
+
+async function retryInvoicePdf(email) {
+  if (!confirm(`Retry PDF generation for ${email}?`)) return;
+  showLoading('Queuing PDF regeneration…');
+  try {
+    const result = await hubPost({ action: 'retryInvoicePdf', memberEmail: email });
+    if (result.error) throw new Error(result.error);
+    await refreshData();
+    showToast('Invoice queued for PDF regeneration. It will generate within ~1 minute.');
+  } catch (err) {
+    showError('Retry failed: ' + err.message);
+  }
+}
 
 async function approveAndSend(email) {
   if (!confirm(`Approve this application and send invoice to ${email}?`)) return;

--- a/docs/onboarding/index.html
+++ b/docs/onboarding/index.html
@@ -841,7 +841,7 @@ function renderApplicationReview(m, invoice, onboarding, googleSearch, name) {
     </div>` : ''}
     ${invoice
       ? `<p style="font-size:.8rem;color:var(--muted);margin-bottom:8px">
-           Invoice #${esc(invoice.invoice_no_)}.
+           Invoice #${esc(invoice.invoice_number)}.
            ${invoice.pdf_status === 'Failed'
              ? `<span style="color:var(--error);font-weight:600;margin-left:8px">⚠ PDF generation failed</span>`
              : invoice.pdf_status === 'Queued' || invoice.pdf_status === 'Generating'
@@ -947,7 +947,7 @@ function renderMemberManagement(m, invoice, onboarding, isLapsed) {
       const lines = transactionsList.filter(t => (t.email || '').toLowerCase() === memberEmail);
       return `
         <p style="font-size:.8rem;color:var(--muted);margin:8px 0 4px">
-          Invoice #${esc(inv.invoice_no_)}
+          Invoice #${esc(inv.invoice_number)}
           ${inv.invoice_link ? `<a href="${esc(inv.invoice_link)}" target="_blank" rel="noopener" style="margin-left:8px">View PDF →</a>` : ''}
         </p>
         <table class="invoice-lines">

--- a/docs/onboarding/index.html
+++ b/docs/onboarding/index.html
@@ -841,7 +841,7 @@ function renderApplicationReview(m, invoice, onboarding, googleSearch, name) {
     </div>` : ''}
     ${invoice
       ? `<p style="font-size:.8rem;color:var(--muted);margin-bottom:8px">
-           Invoice #${esc(invoice.invoice_number || invoice.invoice_number_ || invoice.invoice_no_ || '')}.
+           Invoice #${esc(invoice.invoice_no_)}.
            ${invoice.pdf_status === 'Failed'
              ? `<span style="color:var(--error);font-weight:600;margin-left:8px">⚠ PDF generation failed</span>`
              : invoice.pdf_status === 'Queued' || invoice.pdf_status === 'Generating'
@@ -947,7 +947,7 @@ function renderMemberManagement(m, invoice, onboarding, isLapsed) {
       const lines = transactionsList.filter(t => (t.email || '').toLowerCase() === memberEmail);
       return `
         <p style="font-size:.8rem;color:var(--muted);margin:8px 0 4px">
-          Invoice #${esc(inv.invoice_number || inv.invoice_number_ || inv.invoice_no_ || '')}
+          Invoice #${esc(inv.invoice_no_)}
           ${inv.invoice_link ? `<a href="${esc(inv.invoice_link)}" target="_blank" rel="noopener" style="margin-left:8px">View PDF →</a>` : ''}
         </p>
         <table class="invoice-lines">


### PR DESCRIPTION
## Summary
- Shows pdf_status in the Prospects invoice section: ⏳ generating…, ⚠ failed, or View PDF link
- Adds **Retry PDF** button when pdf_status is `Failed` — calls the `retryInvoicePdf` hub action which resets the row to `Queued` and clears the retry counter
- Approve & Send Invoice tooltip updated when PDF is still generating

## Depends on
Apps Script changes already deployed (@26): queue.js background trigger, retryInvoicePdf hub action in hub.js.

## Test plan
- Q05: Force a generation failure → hub shows ⚠ + Retry PDF button → click Retry → row resets to Queued → trigger generates PDF
- Q02: Submit new member → hub shows ⏳ while Queued → flips to View PDF after trigger runs
- Regression: normal approve flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)