### PR TITLE
feat: onboarding checklist — add missing steps, TI Submitted ticks Club Central Paid

### DIFF
--- a/docs/onboarding/index.html
+++ b/docs/onboarding/index.html
@@ -889,14 +889,16 @@ function renderMemberManagement(m, invoice, onboarding, isLapsed) {
   const isActive    = norm(m.status) === 'active';
 
   const checklistSteps = [
-    { key: 'club_central_registered', label: 'Club Central registered',  col: 'Club Central Registered' },
-    { key: 'club_central_paid',       label: 'Club Central paid',        col: 'Club Central Paid' },
-    { key: 'whatsapp_added',          label: 'Added to WhatsApp',        col: 'WhatsApp Added' },
-    { key: 'calendar_invited',        label: 'Google Calendar invited',  col: 'Calendar Invited' },
-    { key: 'easy_speak_linked',       label: 'Easy-Speak linked',        col: 'Easy-Speak Linked' },
-    { key: 'badge_made',              label: 'Badge ordered',            col: 'Badge Made' },
-    { key: 'invoice_sent',            label: 'Invoice sent',             col: 'Invoice Sent' },
-    { key: 'onboarding_complete',     label: 'Onboarding complete',      col: 'Onboarding Complete' },
+    { key: 'club_central_registered',    label: 'Club Central registered',   col: 'Club Central Registered' },
+    { key: 'club_central_paid',          label: 'Club Central paid',         col: 'Club Central Paid' },
+    { key: 'whatsapp_added',             label: 'Added to WhatsApp',         col: 'WhatsApp Added' },
+    { key: 'calendar_invited',           label: 'Google Calendar invited',   col: 'Calendar Invited' },
+    { key: 'easy_speak_linked',          label: 'Easy-Speak linked',         col: 'Easy-Speak Linked' },
+    { key: 'badge_made',                 label: 'Badge ordered',             col: 'Badge Made' },
+    { key: 'invoice_sent',               label: 'Invoice sent',              col: 'Invoice Sent' },
+    { key: 'member_goals_discussion',    label: 'Member goals discussion',   col: 'Member Goals Discussion' },
+    { key: 'linkedin_follow_connection', label: 'LinkedIn follow/connection', col: 'LinkedIn Follow/Connection' },
+    { key: 'onboarding_complete',        label: 'Onboarding complete',       col: 'Onboarding Complete' },
   ];
 
   const checklistHtml = hasPaidDate


### PR DESCRIPTION
## Summary

- **`hub.js`** `actionMarkTISubmitted_`: when TI Payment Submitted is recorded, also writes today's date to `Club Central Paid` in the Onboarding tab if not already set
- **`index.html`** checklist: adds `Member Goals Discussion` and `LinkedIn Follow/Connection` steps, completing the 10-step canonical onboarding list from T4

## Test plan

- [ ] Mark TI Payment Submitted for a member whose Club Central Paid is blank → confirm Club Central Paid is filled with today's date in the Onboarding tab
- [ ] Mark TI Payment Submitted for a member who already has Club Central Paid set → confirm existing date is not overwritten
- [ ] Open member management panel for a Prospect with a paid invoice → confirm `Member goals discussion` and `LinkedIn follow/connection` appear in the checklist
- [ ] Click each new step → confirm date written to Onboarding tab column

🤖 Generated with [Claude Code](https://claude.com/claude-code)