### PR TITLE
fix: repoint join + onboarding form to prod orphan /exec

### DIFF
--- a/docs/join/index.html
+++ b/docs/join/index.html
@@ -573,7 +573,7 @@
 
 <script>
   // ── CONFIG ─────────────────────────────────────────────────────────────
-  const WEBAPP_URL   = 'https://script.google.com/macros/s/AKfycbwJDm5DcJ3Emm5Q1Gf5mKEzLwZBHcXEetxb1XEGc1Z1q-8hJOdC9mox2LeIG07lP1AnxQ/exec';
+  const WEBAPP_URL   = 'https://script.google.com/macros/s/AKfycbwxaVwyjb0dRYx3AnU1p4g9W0SbiqqlUZPyjOgpWA3KhwcjoSbnOa_gSxM8DrX3kT6t/exec';
   const PAGE_RENDERED_AT = Date.now(); // timing check: bots submit near-instantly
 
   // ── POPULATE JOIN MONTH SELECT ─────────────────────────────────────────

--- a/docs/onboarding/index.html
+++ b/docs/onboarding/index.html
@@ -459,7 +459,7 @@ const GOOGLE_CLIENT_ID = '303221448159-6i35t5bc5k5ukncm1lj36u3qb2731j2d.apps.goo
 
 // Apps Script web app endpoint (doPost).  No sheet ID or OAuth scopes needed
 // client-side — all data access happens server-side via the ID token.
-const WEBAPP_URL = 'https://script.google.com/macros/s/AKfycbwJDm5DcJ3Emm5Q1Gf5mKEzLwZBHcXEetxb1XEGc1Z1q-8hJOdC9mox2LeIG07lP1AnxQ/exec';
+const WEBAPP_URL = 'https://script.google.com/macros/s/AKfycbwxaVwyjb0dRYx3AnU1p4g9W0SbiqqlUZPyjOgpWA3KhwcjoSbnOa_gSxM8DrX3kT6t/exec';
 
 // ══════════════════════════════════════════════════════════════════════════════
 // STATE


### PR DESCRIPTION
## Summary
- Repoints `WEBAPP_URL` in both `docs/join/index.html` and `docs/onboarding/index.html` from the old dev `/exec` (`AKfycbwJDm5DcJ3…`) to the new **prod orphan** `/exec` (`AKfycbwxaVwyjb0dRYx3…`).
- This is Step 7 of the go-live orphan cutover runbook — the committee-owned, prod-sheet-bound Apps Script is now the production runtime.

## ⚠️ Merge/deploy sequencing — do NOT merge early
This repoint sends **live** signups to the prod endpoint. At the moment the prod orphan still runs with `EMAIL_OVERRIDE=true`, which redirects all member mail to the test inbox. If this goes live before the go-live flip, real signups would create prod records but receive **no** welcome/invoice email.

**Merge + publish this only in coordination with runbook Step 9** (`EMAIL_OVERRIDE=false` redeploy on the orphan), and after the Step 8 smoke test confirms the new `/exec` works end-to-end.

## Test plan
- [ ] Step 8 smoke test passes against the new `/exec` (committee runs; row + invoice PDF + override-inbox mail)
- [ ] Step 9 go-live flip (`EMAIL_OVERRIDE=false`) done on the orphan
- [ ] Then merge + publish site so the live form posts to prod