### PR TITLE
fix: hub login crash on non-string sheet header (h.replace is not a function)

### DIFF
--- a/docs/onboarding/index.html
+++ b/docs/onboarding/index.html
@@ -1427,7 +1427,7 @@ function rowsToObjects(rows) {
   return rows.slice(1).map((row, i) => {
     const obj = { _rowNumber: i + 2 };
     headers.forEach((h, j) => {
-      obj[h.replace(/\W+/g, '_').toLowerCase()] = row[j] !== undefined ? row[j] : '';
+      obj[String(h).replace(/\W+/g, '_').toLowerCase()] = row[j] !== undefined ? row[j] : '';
     });
     return obj;
   }).filter(o => Object.values(o).some(v => v !== '' && v !== undefined));


### PR DESCRIPTION
## Summary
- Hub login was failing with **"Failed to load hub data: h.replace is not a function"**.
- Root cause: `rowsToObjects()` treats `rows[0]` as headers and calls `h.replace(...)` on each cell. On the **prod** sheet, one tab's header row contains a non-string value (a number/date where the dev sheet had text), so `.replace` throws and the entire `getAll` load aborts.
- Fix: coerce with `String(h)` before normalising the key — a one-line defensive fix at the sheet-parse boundary. Behaviour is unchanged for the string headers that already worked.

## Notes
- Surfaced during go-live once the hub was repointed to the prod orphan (PR #51) and started reading prod-sheet data.
- Worth a follow-up (owner, not code): check which prod tab has a numeric/date header cell — coercion stops the crash, but if a header was meant to be text it should be fixed at the source so the derived field key matches the dev key.

## Test plan
- [ ] Committee member signs into the onboarding hub → data loads without the `h.replace` error.