### PR TITLE
Link VPM and VPE committee handover docs in hub

### DIFF
--- a/docs/onboarding/index.html
+++ b/docs/onboarding/index.html
@@ -1112,6 +1112,18 @@ function renderResources() {
       description: 'Bank signatory steps, vendor contacts, automation links, and financial procedures.',
       url:         'https://docs.google.com/document/d/1_eDxA9tOf-LoAIIOHshAUdlnW0JM0WS4Hi-zifuxlAc/edit',
     },
+    {
+      title:       'VP Education Handover',
+      alias:       'Jedi Journey Guide',
+      description: 'Educational program: meeting roles, Pathways progress, and approving education awards in Club Central.',
+      url:         'https://docs.google.com/document/d/1oqJUgbiAZxM3YwGsFhaxrbmHvXVelpumU-bJmEbDkEc/edit',
+    },
+    {
+      title:       'VP Membership Handover',
+      alias:       'Force Recruitment Officer',
+      description: 'Membership growth and retention: the guest-to-member pipeline, inductions, and membership campaigns.',
+      url:         'https://docs.google.com/document/d/1SULrBtBp9Me6HWl3a08sjDT09oMthAuw_6DywV6Ar6g/edit',
+    },
   ];
 
   const cards = runbooks.map(r => `


### PR DESCRIPTION
## Summary
- Add **VP Education** (Jedi Journey Guide) and **VP Membership** (Force Recruitment Officer) handover runbooks to the Committee Resources section of the hub, alongside the existing President and Treasurer entries.
- Themed aliases match `docs/committee-roles.md`. Links open only for authenticated committee accounts (the Resources view is gated by the existing server-side committee check); the docs themselves are never published to the public site.

## Test plan
- [x] `node tests/run.js` — front-end jsdom suites pass (24 passed, 0 failed), including the onboarding-hub suite that loads this file.
- [ ] Committee reviewer: sign into the hub, open **Committee Resources**, confirm the two new cards render and each opens the correct Google Doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)